### PR TITLE
Enable custom tailscale advertise(d)-routes

### DIFF
--- a/tailscaleconf/net/usr/lib/tailconf/run.sh
+++ b/tailscaleconf/net/usr/lib/tailconf/run.sh
@@ -7,7 +7,11 @@ ACTION="${1:-start}"
 config_load tailconf
 
 run_tailscale (){
-  SUB=$(uci get network.lan.ipaddr | sed 's/.$/0/')
+  if [ -f /usr/lib/tailconf/advertise-routes ]; then
+    SUB=$(cat /usr/lib/tailconf/advertise-routes | sed ':a;N;$!ba;s/\n/,/g;s/\r//g')
+  else
+    SUB=$(uci get network.lan.ipaddr | sed 's/.$/0/')
+  fi
   cd /usr/share/tailscale || exit 1
   ./tailscaled -tun br-tailscale0 --state /usr/share/tailscale/tailscaled.state 2> /tmp/tailscaled.log &
   ./tailscale up --accept-dns=false --advertise-routes="$SUB/24" --reset >/dev/null 2>&1 &


### PR DESCRIPTION
Allow definition of /usr/lib/tailconf/advertise-routes containing list of custom networks to advertise on tailscale network. can be formatted one per line, or comma separated in CIDR notation.